### PR TITLE
Provide citations

### DIFF
--- a/mind_palace/app.py
+++ b/mind_palace/app.py
@@ -49,11 +49,14 @@ for message in st.session_state.messages:  # Display the prior chat messages
 if st.session_state.messages[-1]["role"] != "assistant":
     with st.chat_message("assistant"):
         with st.spinner("Thinking..."):
-
             response = query_engine.query(prompt)
             st.write(response.response)
-            for source_node in response.source_nodes:
-                st.write(source_node.node.get_text())
 
             message = {"role": "assistant", "content": response.response}
             st.session_state.messages.append(message)  # Add response to message history
+
+    for i, source_node in enumerate(response.source_nodes):
+        st.write(f"[{i+1}]")
+        st.write(f"id: {source_node.node.node_id}")
+        st.write(f"score: {source_node.score}")
+        st.write(f"text: {source_node.node.get_text().split(':', 1)[1]}")


### PR DESCRIPTION
rough working version. it always prints the full text from 3 sources. but at least the response and referenced numbers seem to be correct. e.g. response might cite only [1] but the list of sources printed include all 1, 2, and 3, where 2 and 3 were not cited in response.

adding whatever metadata is easy as we have full control on the underlying nodes. e.g. we can print PDF file name, section name, paragraph number, etc.